### PR TITLE
🐛 fix(brokers): prevent duplicate broker connections

### DIFF
--- a/src/database/cosmos_broker_repository.py
+++ b/src/database/cosmos_broker_repository.py
@@ -22,22 +22,31 @@ Security Note:
     
     In production, actual credentials should be stored in Azure Key Vault.
 
-Cross-Partition Query Policy:
-    This repository explicitly sets enable_cross_partition_query=True for list
-    operations because broker connections span multiple partition keys (broker_type).
+Cross-Partition Query Workaround:
+    Due to a bug in the azure-cosmos SDK async implementation where the
+    enable_cross_partition_query parameter leaks through to aiohttp
+    (causing TypeError in ClientSession._request), this repository uses
+    read_all_items() with client-side filtering instead of query_items().
     
-    SDK 4.x Note: While the Azure Cosmos DB Python SDK 4.x defaults to allowing
-    cross-partition queries, we explicitly set this flag for:
-    1. Self-documenting code - makes the cross-partition intent clear
-    2. Backwards compatibility with older SDK versions
-    3. Explicit acknowledgment of the query cost tradeoffs
+    Workaround Details:
+    - All list operations use read_all_items() to fetch all items
+    - Filtering by is_disabled, broker_type, etc. is done client-side
+    - Deduplication is performed in memory
     
-    This is ACCEPTABLE here because:
-    1. Broker connections are a small dataset (typically <10 items)
-    2. List operations are infrequent (UI load, startup sync)
-    3. Single-broker queries use partition key for efficiency
+    Tradeoffs:
+    - O(n) scan for all queries, where n = total items in container
+    - Acceptable for small datasets (typically <50 broker connections)
+    - More expensive for large datasets or high-frequency polling
     
-    For repositories with large datasets, prefer partition-scoped queries.
+    When to Switch Back:
+    - When azure-cosmos SDK fixes the parameter leaking issue
+    - Use query_items() with enable_cross_partition_query=True for:
+      1. Large datasets (>100 items)
+      2. High-frequency queries (>10/sec)
+      3. Complex filtering that benefits from server-side execution
+    
+    Note: get_connection_by_id_and_type() still uses read_item() with
+    partition key for O(1) lookups when broker_type is known.
 
 Lazy Loading:
     Azure SDK imports are deferred until initialize() is called.
@@ -222,23 +231,22 @@ class CosmosBrokerRepository(IBrokerRepository):
     CONTAINER_NAME = "broker_connections"
     PARTITION_KEY_PATH = "/broker_type"
     
-    def __init__(
-        self,
-        cosmos_endpoint: str = "",
-        database_name: str = "trading-bot",
-    ):
+    def __init__(self):
         """
         Initialize the broker repository.
         
         Uses composition pattern - depends on shared CosmosConnectionPool
         rather than inheriting from CosmosBaseRepository.
         
-        Args:
-            cosmos_endpoint: Cosmos DB endpoint (optional if pool already initialized)
-            database_name: Database name (default: trading-bot)
+        IMPORTANT: CosmosConnectionPool MUST be initialized before calling
+        any repository methods. Call `pool.initialize(endpoint, database)` 
+        during application startup before using this repository.
+        
+        Typical startup order:
+            1. CosmosConnectionPool.get_instance().initialize(endpoint, db_name)
+            2. broker_repo = CosmosBrokerRepository()
+            3. await broker_repo.initialize()
         """
-        self._endpoint = cosmos_endpoint
-        self._database_name = database_name
         self._pool = CosmosConnectionPool.get_instance()
         self._container = None
         self._initialized = False
@@ -313,22 +321,25 @@ class CosmosBrokerRepository(IBrokerRepository):
         """
         Get all broker connections.
         
+        Note: Uses read_all_items() with client-side filtering as a workaround
+        for azure-cosmos SDK bug where enable_cross_partition_query parameter
+        leaks through to aiohttp (TypeError in ClientSession._request).
+        
         Returns:
             List of all broker connection documents
         """
         await self._ensure_initialized()
         
         try:
-            query = "SELECT * FROM c WHERE c._type = 'broker_connection'"
             items = []
             
-            async for item in self._container.query_items(
-                query=query,
-                enable_cross_partition_query=True,
-            ):
-                doc = BrokerConnectionDocument.from_cosmos_doc(item)
-                if doc:
-                    items.append(doc)
+            # Workaround: Use read_all_items() instead of query_items() to avoid
+            # azure-cosmos SDK bug with enable_cross_partition_query parameter
+            async for item in self._container.read_all_items():
+                if item.get('_type') == 'broker_connection':
+                    doc = BrokerConnectionDocument.from_cosmos_doc(item)
+                    if doc:
+                        items.append(doc)
             
             logger.debug(f"Retrieved {len(items)} broker connections")
             return items
@@ -344,26 +355,40 @@ class CosmosBrokerRepository(IBrokerRepository):
         Returns only one connection per (broker_type, is_paper) combination,
         preferring env-configured brokers and newer documents.
         
+        Note: Uses read_all_items() with client-side filtering as a workaround
+        for azure-cosmos SDK bug where enable_cross_partition_query parameter
+        leaks through to aiohttp (TypeError in ClientSession._request).
+        
         Returns:
             List of active (not disabled) broker connections
         """
         await self._ensure_initialized()
         
         try:
-            query = """
-                SELECT * FROM c 
-                WHERE c._type = 'broker_connection' 
-                AND (c.is_disabled = false OR NOT IS_DEFINED(c.is_disabled))
-            """
             raw_items = []
             
-            async for item in self._container.query_items(
-                query=query,
-                enable_cross_partition_query=True,
-            ):
+            logger.info("Executing get_active_connections (using read_all_items workaround)...")
+            
+            # Workaround: Use read_all_items() instead of query_items() to avoid
+            # azure-cosmos SDK bug with enable_cross_partition_query parameter
+            async for item in self._container.read_all_items():
+                # Client-side filtering for broker connections
+                if item.get('_type') != 'broker_connection':
+                    continue
+                    
+                # Filter out disabled connections (same logic as SQL query)
+                is_disabled = item.get('is_disabled')
+                if is_disabled is True:
+                    continue
+                
+                logger.debug(f"Found item: id={item.get('id')}, broker_type={item.get('broker_type')}")
                 doc = BrokerConnectionDocument.from_cosmos_doc(item)
                 if doc:
                     raw_items.append(doc)
+                else:
+                    logger.warning(f"from_cosmos_doc returned None for item: {item.get('id')}")
+            
+            logger.info(f"Read {len(raw_items)} raw active items")
             
             # Deduplicate: keep only one per (broker_type, is_paper)
             # Prefer env-configured brokers, then most recently updated
@@ -383,16 +408,20 @@ class CosmosBrokerRepository(IBrokerRepository):
                         seen[key] = doc
             
             items = list(seen.values())
-            logger.debug(f"Retrieved {len(items)} active broker connections (deduplicated from {len(raw_items)})")
+            logger.info(f"Retrieved {len(items)} active broker connections (deduplicated from {len(raw_items)})")
             return items
             
         except Exception as e:
-            logger.error(f"Failed to get active broker connections: {e}")
+            logger.error(f"Failed to get active broker connections: {e}", exc_info=True)
             return []
     
     async def get_connection(self, connection_id: str) -> Optional[BrokerConnectionDocument]:
         """
         Get a specific broker connection by ID.
+        
+        Note: Uses read_all_items() with client-side filtering as a workaround
+        for azure-cosmos SDK bug where enable_cross_partition_query parameter
+        leaks through to aiohttp (TypeError in ClientSession._request).
         
         Args:
             connection_id: The connection ID to retrieve
@@ -403,16 +432,12 @@ class CosmosBrokerRepository(IBrokerRepository):
         await self._ensure_initialized()
         
         try:
-            # Need to query since we don't know the partition key from just ID
-            query = "SELECT * FROM c WHERE c.id = @id AND c._type = 'broker_connection'"
-            params = [{"name": "@id", "value": connection_id}]
-            
-            async for item in self._container.query_items(
-                query=query,
-                parameters=params,
-                enable_cross_partition_query=True,
-            ):
-                return BrokerConnectionDocument.from_cosmos_doc(item)
+            # Workaround: Use read_all_items() instead of query_items() to avoid
+            # azure-cosmos SDK bug with enable_cross_partition_query parameter
+            async for item in self._container.read_all_items():
+                if (item.get('_type') == 'broker_connection' and 
+                    item.get('id') == connection_id):
+                    return BrokerConnectionDocument.from_cosmos_doc(item)
             
             return None
             
@@ -517,10 +542,14 @@ class CosmosBrokerRepository(IBrokerRepository):
     
     async def disable_connection(self, connection_id: str) -> bool:
         """
-        Mark a connection as disabled (soft delete).
+        Mark a connection as disabled and clear credentials (secure soft delete).
         
-        This is preferred for env-configured brokers since we need to
-        remember that the user disabled them to prevent re-syncing.
+        This is used for env-configured brokers since we need to remember 
+        that the user disabled them to prevent re-syncing from environment.
+        
+        SECURITY: Credentials (api_key_masked, api_key_hash) are cleared to ensure
+        no secrets persist after user requests deletion. Only the minimal record
+        needed to prevent re-sync is kept.
         
         Args:
             connection_id: The connection ID to disable
@@ -535,11 +564,23 @@ class CosmosBrokerRepository(IBrokerRepository):
             if not connection:
                 return False
             
+            # Mark as disabled
             connection.is_disabled = True
             connection.status = "disabled"
+            
+            # SECURITY: Clear all credential-related data
+            connection.api_key_masked = "[DELETED]"
+            connection.api_key_hash = None
+            
+            # Clear sensitive account data
+            connection.balance = 0.0
+            connection.buying_power = 0.0
+            connection.portfolio_value = 0.0
+            connection.open_positions = 0
+            
             await self.save_connection(connection)
             
-            logger.info(f"Disabled broker connection: {connection_id}")
+            logger.info(f"Disabled broker connection and cleared credentials: {connection_id}")
             return True
             
         except Exception as e:
@@ -573,25 +614,25 @@ class CosmosBrokerRepository(IBrokerRepository):
         This is used by BrokerRouter to know which env brokers
         should not be auto-synced.
         
+        Note: Uses read_all_items() with client-side filtering as a workaround
+        for azure-cosmos SDK bug where enable_cross_partition_query parameter
+        leaks through to aiohttp (TypeError in ClientSession._request).
+        
         Returns:
             Set of disabled env broker connection IDs
         """
         await self._ensure_initialized()
         
         try:
-            query = """
-                SELECT c.id FROM c 
-                WHERE c._type = 'broker_connection' 
-                AND c.source = 'env'
-                AND c.is_disabled = true
-            """
             disabled_ids = set()
             
-            async for item in self._container.query_items(
-                query=query,
-                enable_cross_partition_query=True,
-            ):
-                disabled_ids.add(item['id'])
+            # Workaround: Use read_all_items() instead of query_items() to avoid
+            # azure-cosmos SDK bug with enable_cross_partition_query parameter
+            async for item in self._container.read_all_items():
+                if (item.get('_type') == 'broker_connection' and
+                    item.get('source') == 'env' and
+                    item.get('is_disabled') is True):
+                    disabled_ids.add(item['id'])
             
             return disabled_ids
             
@@ -637,24 +678,27 @@ class CosmosBrokerRepository(IBrokerRepository):
                 {"name": "@api_key_masked", "value": api_key_masked},
             ]
             
-            # Note: Using partition key filter (broker_type) so cross-partition not needed
+            # Single-partition query using broker_type as partition key
             async for _ in self._container.query_items(
                 query=query,
                 parameters=params,
+                partition_key=broker_type,
             ):
                 return True  # Found at least one match
             
             return False
             
         except Exception as e:
-            logger.error(f"Failed to check connection existence: {e}")
-            return False
+            # FAIL CLOSED: On error, assume duplicate exists to prevent accidental duplicates
+            logger.error(f"Failed to check connection existence: {e} - failing closed (returning True)")
+            return True
     
     async def connection_exists_by_hash(
         self, 
         broker_type: str, 
         is_paper: bool, 
-        api_key_hash: str
+        api_key_hash: str,
+        exclude_connection_id: Optional[str] = None
     ) -> bool:
         """
         Check if a connection with these parameters already exists using hash.
@@ -666,6 +710,8 @@ class CosmosBrokerRepository(IBrokerRepository):
             broker_type: The broker type
             is_paper: Whether paper trading mode
             api_key_hash: SHA256 hash of the API key
+            exclude_connection_id: Optional connection ID to exclude from the check
+                                   (useful when updating credentials)
             
         Returns:
             True if a matching connection exists
@@ -687,15 +733,82 @@ class CosmosBrokerRepository(IBrokerRepository):
                 {"name": "@api_key_hash", "value": api_key_hash},
             ]
             
-            # Note: Using partition key filter (broker_type) so cross-partition not needed
+            # Exclude a specific connection (e.g., when updating credentials)
+            if exclude_connection_id:
+                query += " AND c.id != @exclude_id"
+                params.append({"name": "@exclude_id", "value": exclude_connection_id})
+            
+            # Single-partition query using broker_type as partition key
             async for _ in self._container.query_items(
                 query=query,
                 parameters=params,
+                partition_key=broker_type,
             ):
                 return True  # Found at least one match
             
             return False
             
         except Exception as e:
-            logger.error(f"Failed to check connection existence by hash: {e}")
+            # FAIL CLOSED: On error, assume duplicate exists to prevent accidental duplicates
+            logger.error(f"Failed to check connection existence by hash: {e} - failing closed (returning True)")
+            return True
+
+    async def connection_exists_by_masked_key(
+        self,
+        broker_type: str,
+        is_paper: bool,
+        api_key_masked: str,
+        source: Optional[str] = None
+    ) -> bool:
+        """
+        Check if a connection with matching masked API key exists.
+        
+        This is a fallback check for env-configured brokers that don't have api_key_hash.
+        Less reliable than hash comparison (only uses last 4 chars), but necessary
+        for detecting duplicates with legacy or env-sourced connections.
+        
+        Args:
+            broker_type: The broker type (e.g., 'alpaca')
+            is_paper: Whether paper trading mode
+            api_key_masked: Masked API key (e.g., '****-****-****-IUEY')
+            source: Optional source filter ('env' or 'user')
+            
+        Returns:
+            True if a matching connection exists
+        """
+        await self._ensure_initialized()
+        
+        try:
+            query = """
+                SELECT c.id FROM c 
+                WHERE c._type = 'broker_connection' 
+                AND c.broker_type = @broker_type
+                AND c.is_paper = @is_paper
+                AND c.api_key_masked = @api_key_masked
+                AND (c.is_disabled = false OR NOT IS_DEFINED(c.is_disabled))
+            """
+            params = [
+                {"name": "@broker_type", "value": broker_type},
+                {"name": "@is_paper", "value": is_paper},
+                {"name": "@api_key_masked", "value": api_key_masked},
+            ]
+            
+            # Optionally filter by source
+            if source:
+                query += " AND c.source = @source"
+                params.append({"name": "@source", "value": source})
+            
+            # Single-partition query using broker_type as partition key
+            async for _ in self._container.query_items(
+                query=query,
+                parameters=params,
+                partition_key=broker_type,
+            ):
+                return True  # Found at least one match
+            
             return False
+            
+        except Exception as e:
+            # FAIL CLOSED: On error, assume duplicate exists to prevent accidental duplicates
+            logger.error(f"Failed to check connection existence by masked key: {e} - failing closed (returning True)")
+            return True

--- a/src/signals/routers/broker_router.py
+++ b/src/signals/routers/broker_router.py
@@ -22,6 +22,7 @@ Author: Trading Bot Team
 Version: 2.0.0
 """
 
+import os
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 import hashlib
@@ -105,7 +106,14 @@ class BrokerConnectionInfo(BaseModel):
     name: str = Field(..., description="Connection display name")
     type: str = Field(default="broker", description="Connection type")
     broker_type: str = Field(..., description="Broker identifier (e.g., 'alpaca')")
-    status: str = Field(..., description="Connection status: connected, disconnected, error, pending")
+    status: str = Field(
+        ..., 
+        description="Connection status: connected, pending_verification, disconnected, error, needs_reauth"
+    )
+    source: str = Field(
+        default="user", 
+        description="Connection source: 'env' (environment configured) or 'user' (UI added)"
+    )
     supported_assets: List[str] = Field(default_factory=list)
     balance: float = Field(default=0.0)
     buying_power: float = Field(default=0.0)
@@ -158,6 +166,68 @@ class TestConnectionResponse(BaseModel):
     broker_type: str
     latency_ms: Optional[float] = None
     account_status: Optional[str] = None
+    message: str
+
+
+class UpdateBrokerCredentials(BaseModel):
+    """Credentials for updating a broker connection.
+    
+    Unlike BrokerCredentials, this does NOT include is_paper since
+    changing paper/live mode is not allowed during updates.
+    """
+    
+    api_key: str = Field(..., min_length=1, description="Broker API key")
+    api_secret: str = Field(..., min_length=1, description="Broker API secret")
+    
+    @field_validator('api_key', 'api_secret')
+    @classmethod
+    def strip_whitespace(cls, v: str) -> str:
+        """Remove leading/trailing whitespace from credentials."""
+        return v.strip()
+
+
+class UpdateBrokerRequest(BaseModel):
+    """Request model for updating a broker connection.
+    
+    Allows updating display name and optionally credentials.
+    Note: Changing broker_type or is_paper mode is NOT supported
+    as these fundamentally change the connection identity.
+    """
+    
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+    
+    name: Optional[str] = Field(
+        default=None,
+        description="New display name for this connection",
+        max_length=100
+    )
+    credentials: Optional[UpdateBrokerCredentials] = Field(
+        default=None,
+        description="New API credentials (if updating). Does not include is_paper."
+    )
+    
+    @field_validator('name', mode='before')
+    @classmethod
+    def strip_name(cls, v: Optional[str]) -> Optional[str]:
+        """Strip whitespace from name."""
+        if v:
+            return v.strip()
+        return v
+
+
+class UpdateBrokerResponse(BaseModel):
+    """Response model for updating a broker connection."""
+    
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+    
+    success: bool
+    connection: Optional[BrokerConnectionInfo] = None
     message: str
 
 
@@ -244,9 +314,11 @@ class BrokerRouter(BaseAdminRouter):
     Provides endpoints for:
     - GET /admin/brokers - List all broker connections
     - POST /admin/brokers - Add a new broker connection
+    - PATCH /admin/brokers/{connection_id} - Update broker display name or credentials
     - DELETE /admin/brokers/{connection_id} - Remove a broker connection
     - POST /admin/brokers/{connection_id}/test - Test broker connectivity
     - GET /admin/brokers/available - List available broker types
+    - POST /admin/brokers/refresh - Force refresh all broker connections from DB/env
     
     Persistence:
         Uses CosmosBrokerRepository to persist broker connections to Cosmos DB.
@@ -309,24 +381,31 @@ class BrokerRouter(BaseAdminRouter):
             logger.debug("Using cached broker connections (skipping DB reload)")
             return
         
+        logger.info("Loading broker connections from DB...")
         await self._ensure_repo_initialized()
         
         try:
             # Get all active (non-disabled) connections from DB
+            logger.debug("Calling get_active_connections()...")
             db_connections = await self._broker_repo.get_active_connections()
+            logger.info(f"get_active_connections() returned {len(db_connections)} documents")
             
             self._connections_cache.clear()
             for doc in db_connections:
+                logger.debug(f"Processing doc: id={doc.id}, broker_type={doc.broker_type}")
                 # Convert document to BrokerConnectionInfo
                 connection = self._doc_to_connection_info(doc)
                 if connection:
                     self._connections_cache[connection.id] = connection
+                    logger.debug(f"Added connection: {connection.id}")
+                else:
+                    logger.warning(f"_doc_to_connection_info returned None for doc: {doc.id}")
             
             self._cache_loaded = True
-            logger.debug(f"Loaded {len(self._connections_cache)} connections from DB")
+            logger.info(f"Loaded {len(self._connections_cache)} connections from DB into cache")
             
         except Exception as e:
-            logger.error(f"Failed to load connections from DB: {e}")
+            logger.error(f"Failed to load connections from DB: {e}", exc_info=True)
             # Continue with empty cache - env brokers will still work
     
     def _doc_to_connection_info(
@@ -345,6 +424,7 @@ class BrokerRouter(BaseAdminRouter):
             type="broker",
             broker_type=doc.broker_type,
             status=doc.status if not doc.is_disabled else "disabled",
+            source=doc.source,
             supported_assets=doc.supported_assets or metadata.get("supported_assets", []),
             balance=doc.balance,
             buying_power=doc.buying_power,
@@ -465,6 +545,24 @@ class BrokerRouter(BaseAdminRouter):
                             f"{'(Paper mode)' if broker_request.credentials.is_paper else '(Live mode)'}"
                 )
             
+            # Also check for env-configured brokers (they don't have api_key_hash)
+            # Compare by masked key to detect if user is adding same credentials as env config
+            masked_key = mask_api_key(broker_request.credentials.api_key)
+            env_duplicate = await self._broker_repo.connection_exists_by_masked_key(
+                broker_type=broker_type,
+                is_paper=broker_request.credentials.is_paper,
+                api_key_masked=masked_key,
+                source="env"
+            )
+            
+            if env_duplicate:
+                return AddBrokerResponse(
+                    success=False,
+                    connection=None,
+                    message=f"This {metadata['name']} account is already configured via environment variables. "
+                            f"Remove the environment configuration first, or use a different account."
+                )
+            
             # Generate connection ID
             import uuid
             connection_id = f"{broker_type}-{str(uuid.uuid4())[:8]}"
@@ -491,6 +589,7 @@ class BrokerRouter(BaseAdminRouter):
                 type="broker",
                 broker_type=broker_type,
                 status="connected",
+                source="user",
                 supported_assets=metadata["supported_assets"],
                 balance=test_result.get("balance", 0.0),
                 buying_power=test_result.get("buying_power", 0.0),
@@ -578,11 +677,21 @@ class BrokerRouter(BaseAdminRouter):
             # For env-configured brokers, use soft delete (disable)
             # This persists the "disabled" state so we don't re-sync them
             if is_env_broker:
-                await self._broker_repo.disable_connection(connection_id)
+                success = await self._broker_repo.disable_connection(connection_id)
+                if not success:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Failed to disable broker connection. Please try again."
+                    )
                 logger.info(f"Disabled env broker connection: {connection_id}")
             else:
                 # For user-added brokers, do hard delete
-                await self._broker_repo.delete_connection(connection_id)
+                success = await self._broker_repo.delete_connection(connection_id)
+                if not success:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Failed to delete broker connection. Please try again."
+                    )
                 logger.info(f"Deleted broker connection: {connection_id}")
             
             # Remove from cache
@@ -591,6 +700,144 @@ class BrokerRouter(BaseAdminRouter):
             return JSONResponse(
                 status_code=HTTPStatus.OK,
                 content={"success": True, "message": "Connection removed"}
+            )
+        
+        @self.router.patch(
+            "/{connection_id}",
+            response_model=UpdateBrokerResponse,
+            summary="Update broker connection",
+            description="Update a broker connection's display name or credentials."
+        )
+        @handle_route_errors("update_broker")
+        async def update_broker(
+            request: Request,
+            connection_id: str,
+            update_request: UpdateBrokerRequest,
+            authorization: Optional[str] = Header(None),
+        ) -> UpdateBrokerResponse:
+            """Update a broker connection.
+            
+            Allows updating:
+            - Display name (rename the connection)
+            - API credentials (requires re-validation)
+            
+            Does NOT allow changing:
+            - Broker type (would require deleting and re-adding)
+            - Paper/live mode (bot has its own demo/live mode)
+            
+            Args:
+                connection_id: The unique connection ID.
+                update_request: Fields to update.
+            
+            Returns:
+                UpdateBrokerResponse with updated connection info.
+            """
+            await self.validate_auth(request, authorization)
+            await self._ensure_repo_initialized()
+            
+            # Fetch existing connection
+            connection_doc = await self._broker_repo.get_connection(connection_id)
+            if not connection_doc:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Connection not found: {connection_id}"
+                )
+            
+            connection = self._doc_to_connection_info(connection_doc)
+            broker_type = connection.broker_type
+            metadata = BROKER_METADATA.get(broker_type, {})
+            
+            # Track what was updated
+            updates_made = []
+            account_data_updated = False  # Track if we should update last_sync
+            
+            # Update display name if provided
+            if update_request.name is not None:
+                new_name = update_request.name.strip()
+                if new_name:
+                    connection_doc.name = new_name
+                    updates_made.append("display name")
+            
+            # Update credentials if provided
+            if update_request.credentials is not None:
+                creds = update_request.credentials
+                
+                # Check for duplicate credentials (same broker type + paper mode + api key)
+                new_api_key_hash = hash_api_key(creds.api_key)
+                duplicate_exists = await self._broker_repo.connection_exists_by_hash(
+                    broker_type=broker_type,
+                    is_paper=connection.is_paper,
+                    api_key_hash=new_api_key_hash,
+                    exclude_connection_id=connection_id
+                )
+                
+                if duplicate_exists:
+                    raise HTTPException(
+                        status_code=HTTPStatus.CONFLICT,
+                        detail="These credentials are already used by another connection."
+                    )
+                
+                # Test new credentials before accepting them
+                test_result = await self._test_broker_connection(
+                    broker_type,
+                    creds.api_key,
+                    creds.api_secret,
+                    connection.is_paper  # Keep same paper/live mode
+                )
+                
+                if not test_result["success"]:
+                    raise HTTPException(
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        detail=f"Credential validation failed: {test_result['message']}"
+                    )
+                
+                # Update credential-related fields
+                connection_doc.api_key_hash = new_api_key_hash
+                connection_doc.api_key_masked = mask_api_key(creds.api_key)
+                
+                # Update account data from test result
+                connection_doc.balance = test_result.get("balance", connection_doc.balance)
+                connection_doc.buying_power = test_result.get("buying_power", connection_doc.buying_power)
+                connection_doc.portfolio_value = test_result.get("portfolio_value", connection_doc.portfolio_value)
+                connection_doc.open_positions = test_result.get("open_positions", connection_doc.open_positions)
+                connection_doc.status = "connected"
+                
+                # Update runtime configuration with new credentials
+                await self._configure_broker_runtime(
+                    broker_type,
+                    creds.api_key,
+                    creds.api_secret,
+                    connection.is_paper
+                )
+                
+                updates_made.append("API credentials")
+                account_data_updated = True  # Credentials update includes account data refresh
+            
+            # Check if any updates were made
+            if not updates_made:
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail="No updates provided. Specify 'name' or 'credentials' to update."
+                )
+            
+            # Only update last_sync when account data was actually refreshed
+            if account_data_updated:
+                connection_doc.last_sync = datetime.utcnow().isoformat()
+            
+            # Persist changes to Cosmos DB
+            await self._broker_repo.save_connection(connection_doc)
+            
+            # Update cache
+            updated_connection = self._doc_to_connection_info(connection_doc)
+            self._connections_cache[connection_id] = updated_connection
+            
+            updates_str = " and ".join(updates_made)
+            logger.info(f"Updated broker connection {connection_id}: {updates_str}")
+            
+            return UpdateBrokerResponse(
+                success=True,
+                connection=updated_connection,
+                message=f"Successfully updated {updates_str} for {metadata.get('name', broker_type)}"
             )
         
         @self.router.post(
@@ -733,6 +980,75 @@ class BrokerRouter(BaseAdminRouter):
             
             return JSONResponse(content={"brokers": available})
         
+        @self.router.get(
+            "/debug",
+            summary="Debug broker connections",
+            description="Debug endpoint to directly query Cosmos DB and return raw data. "
+                       "Only available when ENABLE_ADMIN_DEBUG_ENDPOINTS=true."
+        )
+        @handle_route_errors("debug_brokers")
+        async def debug_brokers(
+            request: Request,
+            authorization: Optional[str] = Header(None),
+        ) -> JSONResponse:
+            """Debug endpoint to see raw Cosmos data. Gated by env var."""
+            # Gate behind explicit environment flag for production safety
+            if not os.environ.get("ENABLE_ADMIN_DEBUG_ENDPOINTS", "").lower() in ("true", "1", "yes"):
+                raise HTTPException(
+                    status_code=404,
+                    detail="Not found"
+                )
+            
+            await self.validate_auth(request, authorization)
+            await self._ensure_repo_initialized()
+            
+            debug_info = {
+                "cache_loaded": self._cache_loaded,
+                "env_brokers_synced": self._env_brokers_synced,
+                "cache_size": len(self._connections_cache),
+                "cache_keys": list(self._connections_cache.keys()),
+            }
+            
+            # Try to get all connections directly
+            try:
+                all_connections = await self._broker_repo.get_all_connections()
+                debug_info["all_connections_count"] = len(all_connections)
+                debug_info["all_connections"] = [
+                    {
+                        "id": c.id,
+                        "broker_type": c.broker_type,
+                        "name": c.name,
+                        "status": c.status,
+                        "is_disabled": c.is_disabled,
+                        "is_paper": c.is_paper,
+                        "source": c.source,
+                    }
+                    for c in all_connections
+                ]
+            except Exception as e:
+                debug_info["all_connections_error"] = str(e)
+            
+            # Try to get active connections
+            try:
+                active_connections = await self._broker_repo.get_active_connections()
+                debug_info["active_connections_count"] = len(active_connections)
+                debug_info["active_connections"] = [
+                    {
+                        "id": c.id,
+                        "broker_type": c.broker_type,
+                        "name": c.name,
+                        "status": c.status,
+                        "is_disabled": c.is_disabled,
+                        "is_paper": c.is_paper,
+                        "source": c.source,
+                    }
+                    for c in active_connections
+                ]
+            except Exception as e:
+                debug_info["active_connections_error"] = str(e)
+            
+            return JSONResponse(content=debug_info)
+        
         @self.router.post(
             "/refresh",
             summary="Refresh broker connections",
@@ -817,6 +1133,22 @@ class BrokerRouter(BaseAdminRouter):
                         logger.debug(f"Loaded {connection_id} from DB into cache")
                         should_skip_alpaca = True
             
+            # Check if a user-added broker with the same API key already exists
+            # This prevents duplicates when user adds broker via UI with same env credentials
+            if not should_skip_alpaca:
+                base_url = self._config.get_config("api.alpaca.base_url", "")
+                is_paper = "paper" in base_url.lower()
+                api_key_hash = hash_api_key(alpaca_key)
+                
+                duplicate_exists = await self._broker_repo.connection_exists_by_hash(
+                    broker_type="alpaca",
+                    is_paper=is_paper,
+                    api_key_hash=api_key_hash
+                )
+                if duplicate_exists:
+                    logger.debug(f"Skipping {connection_id} - user-added broker with same API key exists")
+                    should_skip_alpaca = True
+            
             # Truly new - create with real account data if not skipped
             if not should_skip_alpaca:
                 base_url = self._config.get_config("api.alpaca.base_url", "")
@@ -833,6 +1165,7 @@ class BrokerRouter(BaseAdminRouter):
                     type="broker",
                     broker_type="alpaca",
                     status="connected" if test_result.get("success") else "error",
+                    source="env",
                     supported_assets=["stock", "etf", "crypto"],
                     balance=test_result.get("balance", 0.0),
                     buying_power=test_result.get("buying_power", 0.0),
@@ -877,7 +1210,8 @@ class BrokerRouter(BaseAdminRouter):
                     name="Tastytrade",
                     type="broker",
                     broker_type="tastytrade",
-                    status="connected",
+                    status="pending_verification",  # Not verified - connectivity test not implemented
+                    source="env",
                     supported_assets=["stock", "etf"],
                     api_key_masked="****",
                     is_paper=False,

--- a/trading-terminal/app/brokers/page.tsx
+++ b/trading-terminal/app/brokers/page.tsx
@@ -390,18 +390,256 @@ function AddBrokerDialog({ onBrokerAdded }: { onBrokerAdded?: () => void }) {
 }
 
 /**
+ * Broker Settings Dialog Component
+ */
+function BrokerSettingsDialog({ 
+  broker, 
+  open, 
+  onOpenChange,
+  onUpdated 
+}: { 
+  broker: BrokerConnection
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onUpdated?: () => void
+}) {
+  const [displayName, setDisplayName] = useState(broker.name)
+  const [apiKey, setApiKey] = useState('')
+  const [apiSecret, setApiSecret] = useState('')
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const { toast } = useToast()
+
+  const hasChanges = displayName !== broker.name || apiKey.length > 0 || apiSecret.length > 0
+
+  const handleSave = async () => {
+    if (!hasChanges) return
+    
+    setIsSaving(true)
+    try {
+      const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+      const headers = await getAuthHeaders()
+      
+      // Build update payload - only include changed fields
+      const updatePayload: Record<string, unknown> = {}
+      if (displayName !== broker.name) {
+        updatePayload.name = displayName
+      }
+      if (apiKey && apiSecret) {
+        updatePayload.credentials = {
+          api_key: apiKey,
+          api_secret: apiSecret,
+        }
+      }
+      
+      const response = await fetch(`${API_URL}/api/v1/admin/brokers/${broker.id}`, {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify(updatePayload),
+      })
+      
+      const data = await response.json().catch(() => null)
+      
+      // Check both HTTP status and explicit success flag from response
+      if (response.ok && data?.success === true) {
+        toast({
+          title: 'Settings Updated',
+          description: data?.message || `Successfully updated ${displayName}`,
+        })
+        onOpenChange(false)
+        onUpdated?.()
+        // Reset credential fields
+        setApiKey('')
+        setApiSecret('')
+      } else {
+        toast({
+          title: 'Update Failed',
+          description: data?.message || data?.detail || 'Failed to update broker settings',
+          variant: 'destructive',
+        })
+      }
+    } catch (err) {
+      toast({
+        title: 'Connection Error',
+        description: err instanceof Error ? err.message : 'Failed to connect to server',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  // Reset form when dialog opens
+  React.useEffect(() => {
+    if (open) {
+      setDisplayName(broker.name)
+      setApiKey('')
+      setApiSecret('')
+      setShowApiKey(false)
+    }
+  }, [open, broker.name])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Broker Settings</DialogTitle>
+          <DialogDescription>
+            Update connection settings for {broker.name}
+          </DialogDescription>
+        </DialogHeader>
+        
+        <div className="grid gap-4 py-4">
+          {/* Display Name */}
+          <div className="grid gap-2">
+            <Label htmlFor="displayName">Display Name</Label>
+            <Input
+              id="displayName"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="e.g., My Trading Account"
+            />
+          </div>
+          
+          <Separator />
+          
+          {/* API Credentials Section */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Update API Credentials</Label>
+            <p className="text-xs text-muted-foreground">
+              Leave blank to keep existing credentials. Both fields required to update.
+            </p>
+          </div>
+          
+          <div className="grid gap-2">
+            <Label htmlFor="apiKey">API Key</Label>
+            <div className="relative">
+              <Input
+                id="apiKey"
+                type={showApiKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={broker.apiKeyMasked || 'Enter new API key'}
+                className="pr-10"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3"
+                onClick={() => setShowApiKey(!showApiKey)}
+              >
+                {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+          
+          <div className="grid gap-2">
+            <Label htmlFor="apiSecret">API Secret</Label>
+            <Input
+              id="apiSecret"
+              type="password"
+              value={apiSecret}
+              onChange={(e) => setApiSecret(e.target.value)}
+              placeholder="Enter new API secret"
+            />
+          </div>
+          
+          {/* Validation message */}
+          {(apiKey && !apiSecret) || (!apiKey && apiSecret) ? (
+            <p className="text-xs text-amber-500">
+              Both API Key and Secret are required to update credentials
+            </p>
+          ) : null}
+          
+          {/* Current Connection Info */}
+          <Separator />
+          <div className="rounded-lg bg-muted/50 p-3 space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">Connection Info</p>
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <span className="text-muted-foreground">Broker:</span>
+              <span className="font-medium capitalize">{broker.brokerType || broker.type}</span>
+              <span className="text-muted-foreground">Mode:</span>
+              <span className="font-medium">{broker.isPaper ? 'Paper Trading' : 'Live Trading'}</span>
+              <span className="text-muted-foreground">Status:</span>
+              <span className={cn(
+                'font-medium',
+                broker.status === 'connected' && 'text-green-500',
+                broker.status === 'error' && 'text-red-500'
+              )}>
+                {broker.status}
+              </span>
+            </div>
+          </div>
+        </div>
+        
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button 
+            onClick={handleSave} 
+            disabled={isSaving || !hasChanges || (Boolean(apiKey || apiSecret) && !(apiKey && apiSecret))}
+          >
+            {isSaving ? (
+              <>
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
  * Broker Card Component
  */
-function BrokerCard({ broker, onDeleted }: { broker: BrokerConnection; onDeleted?: () => void }) {
+function BrokerCard({ broker, onDeleted, onRefresh }: { broker: BrokerConnection; onDeleted?: () => void; onRefresh?: () => void }) {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
   const { toast } = useToast()
 
   const handleRefresh = async () => {
     setIsRefreshing(true)
-    await new Promise(resolve => setTimeout(resolve, 1500))
-    setIsRefreshing(false)
+    try {
+      const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+      const headers = await getAuthHeaders()
+      
+      const response = await fetch(`${API_URL}/api/v1/admin/brokers/refresh`, {
+        method: 'POST',
+        headers,
+      })
+      
+      if (response.ok) {
+        toast({
+          title: 'Connections Refreshed',
+          description: 'Successfully refreshed all broker connections',
+        })
+        onRefresh?.()
+      } else {
+        const data = await response.json().catch(() => null)
+        toast({
+          title: 'Refresh Failed',
+          description: data?.message || data?.detail || 'Failed to refresh broker connections',
+          variant: 'destructive',
+        })
+      }
+    } catch (err) {
+      toast({
+        title: 'Connection Error',
+        description: err instanceof Error ? err.message : 'Failed to connect to server',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsRefreshing(false)
+    }
   }
 
   const handleDelete = async () => {
@@ -468,8 +706,8 @@ function BrokerCard({ broker, onDeleted }: { broker: BrokerConnection; onDeleted
               <CardTitle className="text-lg">{broker.name}</CardTitle>
               <div className="flex items-center gap-2 mt-1">
                 <StatusBadge status={broker.status} />
-                <Badge variant="outline" className="text-xs">
-                  {broker.type}
+                <Badge variant="outline" className="text-xs capitalize">
+                  {broker.brokerType || broker.type}
                 </Badge>
               </div>
             </div>
@@ -480,15 +718,29 @@ function BrokerCard({ broker, onDeleted }: { broker: BrokerConnection; onDeleted
               size="sm"
               onClick={handleRefresh}
               disabled={isRefreshing}
+              title="Refresh account data"
             >
               <RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
             </Button>
-            <Button variant="ghost" size="sm">
+            <Button 
+              variant="ghost" 
+              size="sm"
+              onClick={() => setShowSettings(true)}
+              title="Connection settings"
+            >
               <Settings className="h-4 w-4" />
             </Button>
           </div>
         </div>
       </CardHeader>
+      
+      {/* Settings Dialog */}
+      <BrokerSettingsDialog
+        broker={broker}
+        open={showSettings}
+        onOpenChange={setShowSettings}
+        onUpdated={onRefresh}
+      />
 
       <CardContent className="space-y-4">
         {/* Supported Assets */}
@@ -789,18 +1041,22 @@ export default function BrokersPage() {
   const [useDemoMode, setUseDemoMode] = useState(false)
   const { data, isLoading, error, refetch } = useBrokers()
   
-  // Use real data if available, demo data only if explicitly enabled
-  const hasRealData = data !== null && data.connections && data.connections.length > 0
-  const brokers = hasRealData ? data.connections : (useDemoMode ? mockBrokers : [])
-  const isApiAvailable = hasRealData
-  const showEmptyState = !isLoading && !hasRealData && !useDemoMode && !error
+  // Separate "API reachable" from "has brokers" to avoid misleading empty-state
+  const isApiAvailable = data !== null && !error
+  const hasBrokers = isApiAvailable && data.connections && data.connections.length > 0
+  const brokers = hasBrokers ? data.connections : (useDemoMode ? mockBrokers : [])
+  
+  // Show empty state only when API failed to respond (not when list is legitimately empty)
+  const showApiFailedState = !isLoading && !isApiAvailable && !useDemoMode
+  // Show "no brokers configured" when API works but returns empty list
+  const showNoBrokersState = !isLoading && isApiAvailable && !hasBrokers && !useDemoMode
 
-  // Exit demo mode when real data becomes available
+  // Exit demo mode when real brokers become available
   React.useEffect(() => {
-    if (hasRealData && useDemoMode) {
+    if (hasBrokers && useDemoMode) {
       setUseDemoMode(false)
     }
-  }, [hasRealData, useDemoMode])
+  }, [hasBrokers, useDemoMode])
 
   return (
     <ProtectedRoute>
@@ -835,8 +1091,8 @@ export default function BrokersPage() {
               </Card>
             )}
 
-            {/* No Data State - Prompt to enable demo mode */}
-            {showEmptyState && (
+            {/* API Failed State - Connection problem, prompt demo mode */}
+            {showApiFailedState && (
               <Card className="border-muted">
                 <CardContent className="py-12">
                   <div className="flex flex-col items-center justify-center text-center space-y-4">
@@ -844,7 +1100,7 @@ export default function BrokersPage() {
                       <Wifi className="h-8 w-8 text-muted-foreground" />
                     </div>
                     <div className="space-y-2">
-                      <h3 className="text-lg font-semibold">No Broker Data</h3>
+                      <h3 className="text-lg font-semibold">Connection Failed</h3>
                       <p className="text-sm text-muted-foreground max-w-md">
                         Unable to connect to the trading API. Check your backend connection
                         or try demo mode to explore the interface.
@@ -860,6 +1116,27 @@ export default function BrokersPage() {
                         Use Demo Data
                       </Button>
                     </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* No Brokers State - API works but no brokers configured */}
+            {showNoBrokersState && (
+              <Card className="border-dashed border-2">
+                <CardContent className="py-12">
+                  <div className="flex flex-col items-center justify-center text-center space-y-4">
+                    <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center">
+                      <Plus className="h-8 w-8 text-primary" />
+                    </div>
+                    <div className="space-y-2">
+                      <h3 className="text-lg font-semibold">No Brokers Configured</h3>
+                      <p className="text-sm text-muted-foreground max-w-md">
+                        Get started by adding your first broker connection.
+                        You can connect to Alpaca, TastyTrade, or other supported brokers.
+                      </p>
+                    </div>
+                    <AddBrokerDialog onBrokerAdded={refetch} />
                   </div>
                 </CardContent>
               </Card>
@@ -895,13 +1172,13 @@ export default function BrokersPage() {
             </>
           )}
 
-          {/* Error State */}
-          {error && !isLoading && (
+          {/* Error State - only show if not already showing API failed state */}
+          {error && !isLoading && !showApiFailedState && (
             <BrokersError error={error.message} onRetry={refetch} />
           )}
 
           {/* Content (shown only when we have data - real or demo) */}
-          {!isLoading && !showEmptyState && brokers.length > 0 && (
+          {!isLoading && !showApiFailedState && !showNoBrokersState && brokers.length > 0 && (
             <>
               {/* Summary Stats */}
               <SectionErrorBoundary sectionName="Broker Summary">
@@ -912,7 +1189,7 @@ export default function BrokersPage() {
               <SectionErrorBoundary sectionName="Broker Connections">
                 <div className="grid gap-4 md:grid-cols-2">
                   {brokers.map((broker) => (
-                    <BrokerCard key={broker.id} broker={broker} onDeleted={refetch} />
+                    <BrokerCard key={broker.id} broker={broker} onDeleted={refetch} onRefresh={refetch} />
                   ))}
                 </div>
               </SectionErrorBoundary>

--- a/trading-terminal/components/layout/app-shell.tsx
+++ b/trading-terminal/components/layout/app-shell.tsx
@@ -15,6 +15,7 @@ import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/components/auth'
 import { useAppSettings } from '@/lib/contexts'
+import { useBotStatus } from '@/lib/hooks/use-bot-status'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -125,7 +126,7 @@ const navItems: NavItem[] = [
 
 /** Bot status for app shell display */
 interface BotStatusDisplay {
-  status: 'running' | 'paused' | 'stopped' | 'error' | 'created' | 'completed' | 'stopping'
+  status: 'running' | 'paused' | 'stopped' | 'error' | 'created' | 'completed' | 'stopping' | 'checking'
   message?: string
 }
 
@@ -139,6 +140,7 @@ interface AppShellProps {
  */
 function StatusIndicator({ status }: { status: BotStatusDisplay['status'] }) {
   const statusConfig = {
+    checking: { color: 'bg-muted-foreground', icon: AlertTriangle, label: 'Checking...' },
     created: { color: 'bg-muted-foreground', icon: AlertTriangle, label: 'Created' },
     running: { color: 'bg-profit', icon: CheckCircle, label: 'Running' },
     paused: { color: 'bg-warning', icon: AlertTriangle, label: 'Paused' },
@@ -256,6 +258,7 @@ function Sidebar({
                   botStatus.status === 'running' && 'bg-profit animate-pulse',
                   botStatus.status === 'paused' && 'bg-warning',
                   botStatus.status === 'stopped' && 'bg-muted-foreground',
+                  botStatus.status === 'checking' && 'bg-muted-foreground animate-pulse',
                   botStatus.status === 'error' && 'bg-loss animate-pulse'
                 )}
                 title={`Bot ${botStatus.status}`}
@@ -443,9 +446,13 @@ function MobileNav({ botStatus }: { botStatus: BotStatusDisplay }) {
  */
 export function AppShell({
   children,
-  botStatus = { status: 'running', message: 'Processing signals' },
+  botStatus: botStatusProp,
 }: AppShellProps): JSX.Element {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const { botStatus: fetchedStatus } = useBotStatus()
+  
+  // Use prop if provided, otherwise use fetched status from health check
+  const botStatus = botStatusProp ?? fetchedStatus
 
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
- Add bidirectional duplicate detection between UI-added and env-configured brokers
- Add partition_key to query_items() calls for consistent cross-partition behavior
- Implement fail-closed error handling in duplicate detection methods
- Add source field to BrokerConnectionInfo for tracking connection origin
- Fix Tastytrade status to 'pending_verification' instead of misleading 'connected'
- Prevent double error UI rendering in brokers page
- Add connection_exists_by_masked_key() for env broker duplicate detection
- Document CosmosConnectionPool initialization contract

Fixes duplicate broker entries when same credentials used via UI and env config.