### PR TITLE
🐛 fix(brokers): resolve broker loading and duplicate detection issues

### DIFF
--- a/src/database/cosmos_broker_repository.py
+++ b/src/database/cosmos_broker_repository.py
@@ -350,10 +350,10 @@ class CosmosBrokerRepository(IBrokerRepository):
     
     async def get_active_connections(self) -> List[BrokerConnectionDocument]:
         """
-        Get all non-disabled broker connections, deduplicated.
+        Get all non-disabled broker connections.
         
-        Returns only one connection per (broker_type, is_paper) combination,
-        preferring env-configured brokers and newer documents.
+        Returns all active connections without deduplication. Duplicate prevention
+        is handled at insert time via api_key_hash checks, not at read time.
         
         Note: Uses read_all_items() with client-side filtering as a workaround
         for azure-cosmos SDK bug where enable_cross_partition_query parameter
@@ -365,7 +365,7 @@ class CosmosBrokerRepository(IBrokerRepository):
         await self._ensure_initialized()
         
         try:
-            raw_items = []
+            items = []
             
             logger.info("Executing get_active_connections (using read_all_items workaround)...")
             
@@ -384,31 +384,11 @@ class CosmosBrokerRepository(IBrokerRepository):
                 logger.debug(f"Found item: id={item.get('id')}, broker_type={item.get('broker_type')}")
                 doc = BrokerConnectionDocument.from_cosmos_doc(item)
                 if doc:
-                    raw_items.append(doc)
+                    items.append(doc)
                 else:
                     logger.warning(f"from_cosmos_doc returned None for item: {item.get('id')}")
             
-            logger.info(f"Read {len(raw_items)} raw active items")
-            
-            # Deduplicate: keep only one per (broker_type, is_paper)
-            # Prefer env-configured brokers, then most recently updated
-            seen: Dict[tuple, BrokerConnectionDocument] = {}
-            for doc in raw_items:
-                key = (doc.broker_type, doc.is_paper)
-                existing = seen.get(key)
-                
-                if existing is None:
-                    seen[key] = doc
-                elif doc.source == 'env' and existing.source != 'env':
-                    # Prefer env-configured
-                    seen[key] = doc
-                elif doc.source == existing.source:
-                    # Same source - prefer newer (by updated_at)
-                    if doc.updated_at > existing.updated_at:
-                        seen[key] = doc
-            
-            items = list(seen.values())
-            logger.info(f"Retrieved {len(items)} active broker connections (deduplicated from {len(raw_items)})")
+            logger.info(f"Retrieved {len(items)} active broker connections")
             return items
             
         except Exception as e:

--- a/src/signals/routers/broker_router.py
+++ b/src/signals/routers/broker_router.py
@@ -376,10 +376,12 @@ class BrokerRouter(BaseAdminRouter):
         Args:
             force_refresh: If True, reload from DB even if cache is loaded.
                          If False, skip reload if cache is already populated.
+        
+        Note: Always reloads from DB on each request to ensure fresh data.
+        The cache is primarily for within-request consistency, not cross-request caching.
         """
-        if self._cache_loaded and not force_refresh:
-            logger.debug("Using cached broker connections (skipping DB reload)")
-            return
+        # Always reload from DB to ensure we have the latest data
+        # The _cache_loaded flag is now only used within a single request context
         
         logger.info("Loading broker connections from DB...")
         await self._ensure_repo_initialized()
@@ -406,7 +408,7 @@ class BrokerRouter(BaseAdminRouter):
             
         except Exception as e:
             logger.error(f"Failed to load connections from DB: {e}", exc_info=True)
-            # Continue with empty cache - env brokers will still work
+            # Continue with empty cache
     
     def _doc_to_connection_info(
         self, 
@@ -490,11 +492,8 @@ class BrokerRouter(BaseAdminRouter):
             """List all broker connections."""
             await self.validate_auth(request, authorization)
             
-            # Load connections from database
+            # Load connections from database (all user-added brokers)
             await self._load_connections_from_db()
-            
-            # Sync any env-configured brokers (checks DB for disabled status)
-            await self._sync_configured_brokers()
             
             connections = list(self._connections_cache.values())
             
@@ -1060,14 +1059,11 @@ class BrokerRouter(BaseAdminRouter):
             request: Request,
             authorization: Optional[str] = Header(None),
         ) -> BrokersListResponse:
-            """Force refresh broker connections from DB and env configuration."""
+            """Force refresh broker connections from DB."""
             await self.validate_auth(request, authorization)
             
             # Force reload from database
             await self._load_connections_from_db(force_refresh=True)
-            
-            # Force re-sync env brokers (this will make broker API calls)
-            await self._sync_configured_brokers(force_refresh=True)
             
             connections = list(self._connections_cache.values())
             


### PR DESCRIPTION
Backend changes:
- Remove read-time deduplication that was hiding user-added brokers
- Remove env broker sync from list_brokers (brokers are user-managed only)
- Always reload from DB on each request for fresh data
- Add connection_exists_by_masked_key() for env broker duplicate detection
- Add bidirectional duplicate detection between UI and env brokers
- Implement fail-closed error handling in duplicate detection methods

Fixes:
- Brokers stored in Cosmos DB now always appear in the UI
- Duplicate broker connections prevented from both directions
- Removed concept of env-configured brokers for simpler UX